### PR TITLE
Enable .NET Output Caching for the resized images.  

### DIFF
--- a/src/RestImgService/Caching/ImageCachePolicy.cs
+++ b/src/RestImgService/Caching/ImageCachePolicy.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Primitives;
+using RestImgService.ImageFile;
+
+namespace RestImgService.Caching
+{
+    public sealed class ImageCachePolicy : IOutputCachePolicy
+    {
+        /// <summary>
+        /// Custom cache policy for image files.  Want to cache images including the query string
+        /// because the query string specifies the image transformations that are applied.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="cancellation"></param>
+        /// <returns></returns>
+        public ValueTask CacheRequestAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            var pathString = context.HttpContext.Request.Path;
+
+            if (pathString == null || !pathString.HasValue)
+            {
+                return ValueTask.CompletedTask;
+            }
+            var imagePath = new ImagePath(new ImageExtension());
+
+            // only cache images 
+            if (! imagePath.IsImageRequest(pathString))
+            {
+                return ValueTask.CompletedTask;
+            }
+                
+            context.Tags.Add(pathString);
+
+            //default implementation
+            var attemptOutputCaching = AttemptOutputCaching(context);
+            context.EnableOutputCaching = true;
+            context.AllowCacheLookup = attemptOutputCaching;
+            context.AllowCacheStorage = attemptOutputCaching;
+            context.AllowLocking = true;
+
+            // Vary by any query by default
+            context.CacheVaryByRules.QueryKeys = "*";
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ServeFromCacheAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ServeResponseAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            var response = context.HttpContext.Response;
+
+            // Verify existence of cookie headers
+            if (!StringValues.IsNullOrEmpty(response.Headers.SetCookie))
+            {
+                context.AllowCacheStorage = false;
+                return ValueTask.CompletedTask;
+            }
+
+            // Check response code
+            if (response.StatusCode != StatusCodes.Status200OK)
+            {
+                context.AllowCacheStorage = false;
+                return ValueTask.CompletedTask;
+            }
+
+            return ValueTask.CompletedTask;
+        }
+        private static bool AttemptOutputCaching(OutputCacheContext context)
+        {
+            // this policy is intended as a replacement for the default OutputCachePolicy so
+            // we enforce the same rules here
+            var request = context.HttpContext.Request;
+
+            // Verify the method is GET or HEAD
+            if (!HttpMethods.IsGet(request.Method) && !HttpMethods.IsHead(request.Method))
+            {
+                return false;
+            }    
+                
+            // only cache anonymous requests
+            if (!StringValues.IsNullOrEmpty(request.Headers.Authorization) || request.HttpContext.User?.Identity?.IsAuthenticated == true)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/RestImgService/ImageFile/ImageExtension.cs
+++ b/src/RestImgService/ImageFile/ImageExtension.cs
@@ -1,6 +1,6 @@
 ﻿using SkiaSharp;
 
-namespace RestImgService.ImageTransform
+namespace RestImgService.ImageFile
 {
     public class ImageExtension
     {

--- a/src/RestImgService/ImageFile/ImagePath.cs
+++ b/src/RestImgService/ImageFile/ImagePath.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace RestImgService.ImageFile
+{
+    /// <summary>
+    /// Manages the file paths that potentially reference image files
+    /// </summary>
+    public class ImagePath
+    {
+        private readonly ImageExtension _imageExtension;
+        private readonly IWebHostEnvironment? _environment;
+        private PathString _pathString = new PathString();
+
+        public ImagePath(ImageExtension imageExtension)
+        {
+            _imageExtension = imageExtension;
+        }
+        public ImagePath(ImageExtension imageExtension, 
+            IWebHostEnvironment environment) : this(imageExtension)
+        {
+            _environment = environment;
+        }
+        /// <summary>
+        /// Important to call this method before using the ImagePath object.  Gets the PathString
+        /// from the HttpContext, which is not available in the constructor.
+        /// </summary>
+        /// <param name="context"></param>
+        public void SetContext(HttpContext context)
+        {
+            if (context != null && context.Request.Path != null && context.Request.Path.HasValue)
+            {
+                _pathString = context.Request.Path;
+            }
+        }
+        /// <summary>
+        /// Get the full path to the file on the server
+        /// </summary>
+        /// <returns></returns>
+        public string MapImagePath()
+        {
+            if ((!_pathString.HasValue) || (_environment == null))
+            {
+                return String.Empty;
+            }
+
+            return Path.Combine(_environment.WebRootPath ?? String.Empty,
+                _pathString.Value.Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar));
+        }
+        /// <summary>
+        /// get the relative path for the requested file
+        /// </summary>
+        /// <returns></returns>
+        public string GetImagePath()
+        {
+            if (!_pathString.HasValue)
+            {
+                return String.Empty;
+            }
+
+            return _pathString.Value.ToString();
+        }
+        /// <summary>
+        /// determine if the request is for an image file based on the file extension
+        /// </summary>
+        /// <returns></returns>
+        public bool IsImageRequest()
+        {
+            if (!_pathString.HasValue)
+            {
+                return false;
+            }
+            return IsImageRequest(_pathString.Value);
+        }
+        public bool IsImageRequest(string imagePath)
+        {
+            string extension = Path.GetExtension(imagePath).ToLower();
+            return _imageExtension.IsValidExtension(extension);
+        }
+    }
+}

--- a/src/RestImgService/ImageTransform/EncodedImage.cs
+++ b/src/RestImgService/ImageTransform/EncodedImage.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using RestImgService.ImageFile;
+using SkiaSharp;
 
 namespace RestImgService.ImageTransform
 {
@@ -24,7 +25,7 @@ namespace RestImgService.ImageTransform
         }
         public void Dispose()
         {
-            _image.Dispose();
+            // we don't "own" the image so we don't dispose it
         }
     }
 }

--- a/src/RestImgService/ImageTransform/ImageData.cs
+++ b/src/RestImgService/ImageTransform/ImageData.cs
@@ -12,10 +12,14 @@ namespace RestImgService.ImageTransform
         {
             this.sKData = sKData;
         }
+        public ImageData(byte[] data) : this(SKData.CreateCopy(data))
+        {
+        }
         public byte[] ToArray()
         {
             return sKData.ToArray();
         }
+
         public long Size => sKData.Size;
         public void Dispose()
         {

--- a/src/RestImgService/ImageTransform/TransformCache.cs
+++ b/src/RestImgService/ImageTransform/TransformCache.cs
@@ -1,36 +1,88 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
 using SkiaSharp;
+using RestImgService.ImageFile;
+using Microsoft.Extensions.Primitives;
 
 namespace RestImgService.ImageTransform
 {
+    /// <summary>
+    /// cache of images that have been transformed.
+    /// the cache contains the original images before transformation.  the transformed images are not cached.
+    /// .NET OutputCaching will be used to cache the resized images.
+    /// </summary>
     public class TransformCache
     {
-        private IMemoryCache _memoryCache;
+        const int CACHE_DURATION_MINUTES = 5;
 
-        public TransformCache(IMemoryCache memoryCache)
+        private readonly IMemoryCache _memoryCache;
+        private readonly ILogger<TransformCache> _logger;
+
+        public TransformCache(IMemoryCache memoryCache,
+            ILogger<TransformCache> logger)
         {
             _memoryCache = memoryCache;
+            _logger = logger;
         }
-        public int GetCacheKey(string imagePath, TransformRequest transformRequest)
+        protected string GetCacheKey(ImagePath imagePath, TransformRequest transformRequest)
         {
-            return HashCode.Combine(imagePath, transformRequest.Width, transformRequest.Height,
-                transformRequest.Quality, transformRequest.Format);
+            return imagePath.GetImagePath();
         }
-        public ImageData? Get(string imagePath, TransformRequest transformRequest)
+        /// <summary>
+        /// return the cached PixelMap for the given image path and transform request, if one exists
+        /// </summary>
+        /// <param name="imagePath"></param>
+        /// <param name="transformRequest"></param>
+        /// <returns></returns>
+        public PixelMap? Get(ImagePath imagePath, TransformRequest transformRequest)
         {
-            int cacheKey = GetCacheKey(imagePath, transformRequest);
-            byte[]? imageBytes;
-            bool isCached = _memoryCache.TryGetValue(cacheKey, out imageBytes);
+            string cacheKey = GetCacheKey(imagePath, transformRequest);
+            PixelMap? pixelMap;
+            bool isCached = _memoryCache.TryGetValue(cacheKey, out pixelMap);
             if (isCached)
             {
-                return new ImageData(SKData.CreateCopy(imageBytes));
+                return pixelMap;
             }
             return null;
         }
-        public void Set(string imagePath, TransformRequest transformRequest, ImageData imageData)
+        /// <summary>
+        /// cache the PixelMap for the given image path and transform request
+        /// </summary>
+        /// <param name="imagePath"></param>
+        /// <param name="transformRequest"></param>
+        /// <param name="pixelMap"></param>
+        public void Set(ImagePath imagePath, TransformRequest transformRequest, PixelMap pixelMap)
         {
-            int cacheKey = GetCacheKey(imagePath, transformRequest);
-            _memoryCache.Set(cacheKey, imageData.ToArray());
+            TimeSpan expirationMinutes = TimeSpan.FromMinutes(CACHE_DURATION_MINUTES);
+
+            var expirationTime = DateTime.Now.Add(expirationMinutes);
+
+            // need to use options to set custom callback for disposing the pixelmap
+            var cacheEntryOptions = new MemoryCacheEntryOptions()
+                .SetSlidingExpiration(expirationMinutes)
+                .RegisterPostEvictionCallback(callback: RemovedCallback, state: this);
+
+            string cacheKey = GetCacheKey(imagePath, transformRequest);
+            _memoryCache.Set(cacheKey, pixelMap, cacheEntryOptions);
+        }
+        /// <summary>
+        /// Calls IDisposable.Dispose on objects when they are removed from the cache
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="reason"></param>
+        /// <param name="state"></param>
+        private static void RemovedCallback(object key, object? value, EvictionReason reason, object? state)
+        {
+            if (reason != EvictionReason.Removed)
+            {
+                var item = value as IDisposable;
+                if (item != null)
+                {
+                    item.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/RestImgService/ImageTransform/TransformRequest.cs
+++ b/src/RestImgService/ImageTransform/TransformRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace RestImgService.ImageTransform
+﻿using RestImgService.ImageFile;
+
+namespace RestImgService.ImageTransform
 {
     public class TransformRequest
     {

--- a/src/RestImgService/RestImgMiddlewareExtensions.cs
+++ b/src/RestImgService/RestImgMiddlewareExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using RestImgService.Caching;
+using RestImgService.ImageFile;
 using RestImgService.ImageTransform;
 
 namespace RestImgService
@@ -8,15 +10,23 @@ namespace RestImgService
     {
         public static IApplicationBuilder UseRestImg(this IApplicationBuilder app)
         {
-            return app.UseMiddleware<RestImgMiddleware>();
+            return app.UseOutputCache().
+                UseMiddleware<RestImgMiddleware>();
         }
         public static void AddRestImg(this IServiceCollection services)
         {
             services.AddMemoryCache();
+            services.AddOutputCache(options =>
+            {
+                options.AddBasePolicy(policy => policy
+                    .AddPolicy<ImageCachePolicy>()
+                    .Expire(TimeSpan.FromMinutes(5)));
+            });
             services.AddTransient<DynamicImage>();
             services.AddTransient<TransformRequestReader>();
             services.AddTransient<ImageExtension>();
             services.AddTransient<TransformCache>();
+            services.AddTransient<ImagePath>();
         }
     }
 }

--- a/src/RestImgService/RestImgService.csproj
+++ b/src/RestImgService/RestImgService.csproj
@@ -10,5 +10,6 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="SkiaSharp" Version="2.88.8" />
+	  <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Update use of internal memory cache for the raw images before transformations.